### PR TITLE
Add a stub auth implementation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ See the [REST API documentation](site:pulp_rust/restapi/) for detailed endpoint 
 
 - [Use Pulp as a pull-through cache](site:pulp_rust/docs/user/guides/pull-through-cache/) for crates.io or any Cargo sparse registry
 - [Host a private Cargo registry](site:pulp_rust/docs/user/guides/private-registry/) for internal crates
+- Publish crates with `cargo publish` and manage them with `cargo yank`
 - Implements the [Cargo sparse registry protocol](https://doc.rust-lang.org/cargo/reference/registry-index.html#sparse-index) for compatibility with standard Cargo tooling
 - Download crates on-demand to reduce disk usage
 - Every operation creates a restorable snapshot with Versioned Repositories

--- a/docs/user/guides/private-registry.md
+++ b/docs/user/guides/private-registry.md
@@ -4,10 +4,6 @@ This guide walks you through setting up Pulp as a private Cargo registry for hos
 crates. This is useful for organizations that need to distribute proprietary or internal-only
 Rust packages.
 
-!!! note
-    Package publishing support (`cargo publish`) is not yet available but is planned for an
-    upcoming release. In the meantime, content can be uploaded through the Pulp REST API.
-
 ## Create a Repository
 
 ```bash
@@ -16,13 +12,15 @@ pulp rust repository create --name my-crates
 
 ## Create a Distribution
 
-A distribution makes the repository's content available to Cargo over HTTP.
+A distribution makes the repository's content available to Cargo over HTTP. Set `--allow-uploads`
+to enable publishing crates via `cargo publish`.
 
 ```bash
 pulp rust distribution create \
     --name my-crates \
     --base-path my-crates \
-    --repository my-crates
+    --repository my-crates \
+    --allow-uploads
 ```
 
 Your private registry is now served at `http://<pulp-host>/pulp/cargo/my-crates/`.
@@ -34,6 +32,58 @@ Add the private registry to your Cargo configuration. Create or edit `~/.cargo/c
 ```toml
 [registries.my-crates]
 index = "sparse+http://<pulp-host>/pulp/cargo/my-crates/"
+```
+
+## Authentication
+
+State-changing operations (publishing, yanking, and unyanking) require an authorization token.
+Configure the token for your registry in `~/.cargo/credentials.toml`:
+
+```toml
+[registries.my-crates]
+token = "i_understand_that_pulp_rust_does_not_support_proper_auth_yet"
+```
+
+Alternatively, you can pass the token on the command line:
+
+```bash
+cargo publish --registry my-crates --token "i_understand_that_pulp_rust_does_not_support_proper_auth_yet"
+```
+
+!!! warning
+    This is a temporary stub token. Proper token-based authentication is planned for a future
+    release. The stub token exists to ensure that the authentication workflow is exercised and that
+    state-changing operations are not completely open.
+
+Read-only operations (downloading crates, browsing the index) do not require a token.
+
+## Publish a Crate
+
+Once the registry is configured and a distribution with `--allow-uploads` exists, you can publish
+crates using standard Cargo tooling:
+
+```bash
+cargo publish --registry my-crates
+```
+
+This uploads the crate to Pulp, which creates the artifact, content metadata, and a new repository
+version. The crate is immediately available for download through the distribution.
+
+Publishing the same crate version twice is rejected — crate versions are immutable, consistent
+with crates.io behavior.
+
+## Yank and Unyank
+
+Yanking marks a crate version as unavailable for new dependency resolution, while still allowing
+existing projects that already depend on it to continue downloading it. This matches the
+[crates.io yank semantics](https://doc.rust-lang.org/cargo/reference/publishing.html#cargo-yank).
+
+```bash
+# Yank a version
+cargo yank --registry my-crates --version 1.0.0 my-crate
+
+# Unyank a version
+cargo yank --registry my-crates --version 1.0.0 --undo my-crate
 ```
 
 ### Using the Private Registry as a Dependency Source

--- a/pulp_rust/app/auth.py
+++ b/pulp_rust/app/auth.py
@@ -1,0 +1,37 @@
+"""Stub authentication for Cargo API endpoints.
+
+This is a temporary placeholder — it validates the Authorization header against
+a hardcoded token so that state-changing endpoints (publish, yank, unyank) are
+not completely open.  It will be replaced by proper token-based auth later.
+"""
+
+import functools
+import json
+
+from django.http import HttpResponse
+
+STUB_TOKEN = "i_understand_that_pulp_rust_does_not_support_proper_auth_yet"
+
+
+def require_cargo_token(view_method):
+    """Decorator that validates the Cargo Authorization header against the stub token.
+
+    Returns a 403 with a Cargo-style JSON error if the token is missing or incorrect.
+    """
+
+    @functools.wraps(view_method)
+    def wrapper(self, request, *args, **kwargs):
+        token = request.META.get("HTTP_AUTHORIZATION")
+        if token == STUB_TOKEN:
+            return view_method(self, request, *args, **kwargs)
+        if not token:
+            detail = "this endpoint requires an authorization token"
+        else:
+            detail = "invalid authorization token"
+        return HttpResponse(
+            json.dumps({"errors": [{"detail": detail}]}),
+            content_type="application/json",
+            status=403,
+        )
+
+    return wrapper

--- a/pulp_rust/app/models.py
+++ b/pulp_rust/app/models.py
@@ -17,6 +17,10 @@ from pulpcore.plugin.util import get_domain_pk
 
 logger = getLogger(__name__)
 
+# Cache for the "dl" template from each registry's config.json.
+# Keyed by index URL; effectively never changes for a given registry.
+_dl_template_cache = {}
+
 
 def _strip_sparse_prefix(url):
     """Strip the sparse+ prefix from a Cargo registry URL."""
@@ -194,9 +198,8 @@ class RustDependency(models.Model):
         default="normal",
     )
 
-    # @TODO: I suspect this isn't needed
-    # URL of alternative registry if dependency comes from a non-default registry
-    # Null means the dependency is from the same registry as the parent package
+    # URL of alternative registry if dependency comes from a non-default registry.
+    # Null means the dependency is from the same registry as the parent package.
     registry = models.CharField(max_length=512, blank=True, null=True)
 
     # Original crate name if the dependency was renamed
@@ -235,11 +238,12 @@ class RustRemote(Remote):
         crate_name, version = _parse_crate_relative_path(relative_path)
         index_url = _strip_sparse_prefix(self.url).rstrip("/")
 
-        # TODO: Cache the config.json response to avoid fetching it on every request.
-        config_url = f"{index_url}/config.json"
-        response = urllib.request.urlopen(config_url)
-        config = json.loads(response.read())
-        dl_template = config["dl"]
+        if index_url not in _dl_template_cache:
+            config_url = f"{index_url}/config.json"
+            response = urllib.request.urlopen(config_url, timeout=30)
+            config = json.loads(response.read())
+            _dl_template_cache[index_url] = config["dl"]
+        dl_template = _dl_template_cache[index_url]
 
         if "{crate}" in dl_template or "{version}" in dl_template:
             return dl_template.replace("{crate}", crate_name).replace("{version}", version)

--- a/pulp_rust/app/urls.py
+++ b/pulp_rust/app/urls.py
@@ -5,6 +5,7 @@ from pulp_rust.app.views import (
     IndexRoot,
     CargoIndexApiViewSet,
     CargoDownloadApiView,
+    CargoMeApiView,
     CargoPublishApiView,
 )
 
@@ -15,6 +16,11 @@ else:
 
 
 urlpatterns = [
+    path(
+        CRATES_IO_URL + "me",
+        CargoMeApiView.as_view(),
+        name="cargo-me-api",
+    ),
     path(
         CRATES_IO_URL + "api/v1/crates/new",
         CargoPublishApiView.as_view(),

--- a/pulp_rust/app/views.py
+++ b/pulp_rust/app/views.py
@@ -1,5 +1,7 @@
 import json
 import logging
+import os
+import struct
 import tempfile
 import urllib.request
 import urllib.error
@@ -29,6 +31,7 @@ from pulp_rust.app.models import (
     RustPackageYank,
     _strip_sparse_prefix,
 )
+from pulp_rust.app.auth import require_cargo_token
 from pulp_rust.app.tasks import (
     ayank_package,
     aunyank_package,
@@ -76,7 +79,7 @@ class ApiMixin:
         try:
             return distro_qs.get(base_path=repo, pulp_domain=get_domain())
         except ObjectDoesNotExist:
-            raise Http404(f"No RustDistribution found for base_path {repo}")  # TODO: broken
+            raise Http404(f"No RustDistribution found for base_path {repo}")
 
     @staticmethod
     def get_repository_version(distribution):
@@ -180,7 +183,7 @@ class CargoIndexApiViewSet(ApiMixin, ViewSet):
             index_url = _strip_sparse_prefix(remote.url).rstrip("/")
             upstream_url = f"{index_url}/{path}"
             try:
-                response = urllib.request.urlopen(upstream_url)
+                response = urllib.request.urlopen(upstream_url, timeout=30)
                 return HttpResponse(response.read(), content_type="text/plain")
             except urllib.error.HTTPError as e:
                 if e.code == 404:
@@ -258,6 +261,23 @@ class IndexRoot(ApiMixin, ViewSet):
         return HttpResponse(json.dumps(data), content_type="application/json")
 
 
+class CargoMeApiView(APIView):
+    """
+    Auth verification endpoint for ``cargo login``.
+
+    Cargo calls GET /me after login to verify the token is valid.
+    See: https://doc.rust-lang.org/cargo/reference/registry-web-api.html
+    """
+
+    authentication_classes = []
+    permission_classes = []
+    renderer_classes = [JSONRenderer]
+
+    @require_cargo_token
+    def get(self, request, **kwargs):
+        return HttpResponse(json.dumps({"ok": True}), content_type="application/json")
+
+
 class CargoPublishApiView(APIView):
     """
     View for Cargo's crate publish endpoint (PUT /api/v1/crates/new).
@@ -268,9 +288,8 @@ class CargoPublishApiView(APIView):
     See: https://doc.rust-lang.org/cargo/reference/registry-web-api.html#publish
     """
 
-    # TODO: Authentication/authorization is not yet implemented.
-    # All users with network access can publish. In production, this should
-    # require a valid token and verify crate ownership.
+    # Authentication uses a stub token via @require_cargo_token decorator.
+    # TODO: Replace with proper per-user token auth and RBAC integration.
     authentication_classes = []
     permission_classes = []
     renderer_classes = [JSONRenderer]
@@ -288,6 +307,7 @@ class CargoPublishApiView(APIView):
             status=status,
         )
 
+    @require_cargo_token
     def put(self, request, **kwargs):
         """
         Handle ``cargo publish`` requests.
@@ -308,7 +328,7 @@ class CargoPublishApiView(APIView):
 
         try:
             metadata, crate_bytes = parse_cargo_publish_body(request.body)
-        except Exception:
+        except (struct.error, json.JSONDecodeError, UnicodeDecodeError):
             return self._error_response("invalid publish request body")
 
         name = metadata.get("name")
@@ -327,17 +347,20 @@ class CargoPublishApiView(APIView):
         tmp.write(crate_bytes)
         tmp.close()
 
-        task = dispatch(
-            apublish_package,
-            exclusive_resources=[distro.repository],
-            immediate=True,
-            kwargs={
-                "repository_pk": str(distro.repository.pk),
-                "metadata": metadata,
-                "crate_path": tmp.name,
-            },
-        )
-        has_task_completed(task)
+        try:
+            task = dispatch(
+                apublish_package,
+                exclusive_resources=[distro.repository],
+                immediate=True,
+                kwargs={
+                    "repository_pk": str(distro.repository.pk),
+                    "metadata": metadata,
+                    "crate_path": tmp.name,
+                },
+            )
+            has_task_completed(task)
+        finally:
+            os.unlink(tmp.name)
 
         return HttpResponse(
             json.dumps(
@@ -363,7 +386,7 @@ class CargoDownloadApiView(APIView):
     permission_classes = []
     renderer_classes = [PlainTextRenderer, JSONRenderer]
 
-    def get_full_path(self, base_path, pulp_domain=None):  # TODO: replace with ApiMixin?
+    def get_full_path(self, base_path, pulp_domain=None):
         if settings.DOMAIN_ENABLED:
             domain = pulp_domain or get_domain()
             return f"{domain.name}/{base_path}"
@@ -393,10 +416,11 @@ class CargoDownloadApiView(APIView):
             relative_path = f"{name}/{name}-{version}.crate"
             return self.redirect_to_content_app(distro, relative_path, request)
         elif rest == "readme":
-            raise NotImplementedError("Readme endpoint is not yet implemented")
+            raise Http404("Readme endpoint is not yet implemented")
         else:
             raise Http404(f"Unknown action: {rest}")
 
+    @require_cargo_token
     def delete(self, request, name, version, rest, **kwargs):
         """
         Responds to DELETE requests for yanking crate versions.
@@ -436,6 +460,7 @@ class CargoDownloadApiView(APIView):
         has_task_completed(task)
         return HttpResponse(json.dumps({"ok": True}), content_type="application/json")
 
+    @require_cargo_token
     def put(self, request, name, version, rest, **kwargs):
         """
         Responds to PUT requests for unyanking crate versions.

--- a/pulp_rust/tests/functional/api/test_auth.py
+++ b/pulp_rust/tests/functional/api/test_auth.py
@@ -1,0 +1,144 @@
+"""Tests for stub authentication on Cargo API endpoints."""
+
+from urllib.parse import urljoin
+
+from pulp_rust.tests.functional.utils import (
+    CARGO_AUTH_HEADERS,
+    cargo_api_request,
+    download_file,
+    get_index_entry,
+    minimal_publish_request,
+)
+
+# --- 403 tests for missing/wrong token ---
+
+
+def test_publish_without_token_returns_403(
+    rust_repo_factory,
+    rust_distribution_factory,
+    cargo_registry_url,
+):
+    """Publish without an Authorization header should return 403."""
+    repository = rust_repo_factory()
+    distribution = rust_distribution_factory(repository=repository.pulp_href, allow_uploads=True)
+    base = cargo_registry_url(distribution.base_path)
+
+    response = minimal_publish_request(base)
+    assert response.status_code == 403
+    errors = response.json()["errors"]
+    assert any("authorization token" in e["detail"] for e in errors)
+
+
+def test_publish_with_wrong_token_returns_403(
+    rust_repo_factory,
+    rust_distribution_factory,
+    cargo_registry_url,
+):
+    """Publish with an incorrect token should return 403."""
+    repository = rust_repo_factory()
+    distribution = rust_distribution_factory(repository=repository.pulp_href, allow_uploads=True)
+    base = cargo_registry_url(distribution.base_path)
+
+    response = minimal_publish_request(base, headers={"Authorization": "wrong-token"})
+    assert response.status_code == 403
+    errors = response.json()["errors"]
+    assert any("invalid" in e["detail"] for e in errors)
+
+
+def test_yank_without_token_returns_403(
+    rust_repo_factory,
+    rust_distribution_factory,
+    cargo_registry_url,
+):
+    """Yank without an Authorization header should return 403."""
+    repository = rust_repo_factory()
+    distribution = rust_distribution_factory(repository=repository.pulp_href)
+    base = cargo_registry_url(distribution.base_path)
+
+    yank_url = urljoin(base, "api/v1/crates/fake/0.0.1/yank")
+    response = cargo_api_request("DELETE", yank_url)
+    assert response.status_code == 403
+    errors = response.json()["errors"]
+    assert any("authorization token" in e["detail"] for e in errors)
+
+
+def test_unyank_without_token_returns_403(
+    rust_repo_factory,
+    rust_distribution_factory,
+    cargo_registry_url,
+):
+    """Unyank without an Authorization header should return 403."""
+    repository = rust_repo_factory()
+    distribution = rust_distribution_factory(repository=repository.pulp_href)
+    base = cargo_registry_url(distribution.base_path)
+
+    unyank_url = urljoin(base, "api/v1/crates/fake/0.0.1/unyank")
+    response = cargo_api_request("PUT", unyank_url)
+    assert response.status_code == 403
+    errors = response.json()["errors"]
+    assert any("authorization token" in e["detail"] for e in errors)
+
+
+# --- /me endpoint (cargo login verification) ---
+
+
+def test_me_with_valid_token(
+    rust_repo_factory,
+    rust_distribution_factory,
+    cargo_registry_url,
+):
+    """/me with a valid token should return 200 {"ok": true}."""
+    repository = rust_repo_factory()
+    distribution = rust_distribution_factory(repository=repository.pulp_href)
+    base = cargo_registry_url(distribution.base_path)
+
+    response = cargo_api_request("GET", urljoin(base, "me"), headers=CARGO_AUTH_HEADERS)
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+
+
+def test_me_without_token_returns_403(
+    rust_repo_factory,
+    rust_distribution_factory,
+    cargo_registry_url,
+):
+    """/me without a token should return 403."""
+    repository = rust_repo_factory()
+    distribution = rust_distribution_factory(repository=repository.pulp_href)
+    base = cargo_registry_url(distribution.base_path)
+
+    response = cargo_api_request("GET", urljoin(base, "me"))
+    assert response.status_code == 403
+
+
+def test_me_with_wrong_token_returns_403(
+    rust_repo_factory,
+    rust_distribution_factory,
+    cargo_registry_url,
+):
+    """/me with an invalid token should return 403."""
+    repository = rust_repo_factory()
+    distribution = rust_distribution_factory(repository=repository.pulp_href)
+    base = cargo_registry_url(distribution.base_path)
+
+    response = cargo_api_request("GET", urljoin(base, "me"), headers={"Authorization": "wrong"})
+    assert response.status_code == 403
+
+
+# --- Public endpoints remain accessible without token ---
+
+
+def test_download_without_token_succeeds(populated_repo):
+    """Downloads should work without any authorization token."""
+    base_url = populated_repo["base_url"]
+    download_url = urljoin(base_url, "api/v1/crates/itoa/1.0.0/download")
+    result = download_file(download_url)
+    assert result.response_obj.status == 200
+
+
+def test_index_without_token_succeeds(populated_repo):
+    """The sparse index should be accessible without any authorization token."""
+    base_url = populated_repo["base_url"]
+    entry = get_index_entry(base_url, "it/oa/itoa", "1.0.0")
+    assert entry is not None
+    assert entry["name"] == "itoa"

--- a/pulp_rust/tests/functional/api/test_publish.py
+++ b/pulp_rust/tests/functional/api/test_publish.py
@@ -1,81 +1,22 @@
-"""Tests for the Cargo publish API (PUT /api/v1/crates/new)."""
+"""Tests for the Cargo publish API (PUT /api/v1/crates/new).
 
-import json
-import struct
-
-import requests
+NOTE: The test helpers (build_publish_metadata, cargo_publish) reuse
+pulp_rust's own extract_cargo_toml / extract_dependencies to build the
+publish request — the same code the server uses to process it.  The index
+fidelity tests below validate that code path by comparing Pulp's index
+output against independently-fetched crates.io data.  If those app
+functions ever produce wrong results, these fidelity tests are what will
+catch it.  Other test modules (auth, yank) also depend on the same helpers,
+so keep these fidelity checks passing.
+"""
 
 from pulp_rust.tests.functional.utils import (
     assert_index_entry_matches_upstream,
+    build_publish_metadata,
+    cargo_publish,
     download_crate_from_upstream,
     get_index_entry,
 )
-from pulp_rust.app.utils import extract_cargo_toml, extract_dependencies
-
-
-def build_cargo_publish_body(metadata, crate_bytes):
-    """Build the binary request body that ``cargo publish`` sends.
-
-    Format (per Cargo registry web API spec):
-        4 bytes: JSON metadata length (little-endian u32)
-        N bytes: JSON metadata (UTF-8)
-        4 bytes: .crate file length (little-endian u32)
-        M bytes: .crate file (binary)
-    """
-    json_bytes = json.dumps(metadata).encode("utf-8")
-    return (
-        struct.pack("<I", len(json_bytes))
-        + json_bytes
-        + struct.pack("<I", len(crate_bytes))
-        + crate_bytes
-    )
-
-
-def cargo_publish(url, metadata, crate_bytes):
-    """Send a publish request mimicking ``cargo publish``.
-
-    Cargo sends Content-Type: application/json even though the body is a
-    custom binary format, not valid JSON.
-    """
-    body = build_cargo_publish_body(metadata, crate_bytes)
-    return requests.put(
-        f"{url}api/v1/crates/new",
-        data=body,
-        headers={"Content-Type": "application/json"},
-        verify=False,
-    )
-
-
-def build_publish_metadata(crate_path, crate_name, crate_version):
-    """Extract metadata from a .crate file and format it for the publish API.
-
-    Cargo uses "version_req" (not "req") and "explicit_name_in_toml" (not "package")
-    per the Cargo registry web API spec.
-    """
-    cargo_toml = extract_cargo_toml(crate_path, crate_name, crate_version)
-    deps = extract_dependencies(cargo_toml)
-
-    return {
-        "name": crate_name,
-        "vers": crate_version,
-        "deps": [
-            {
-                "name": dep["name"],
-                "version_req": dep["req"],
-                "features": dep["features"],
-                "optional": dep["optional"],
-                "default_features": dep["default_features"],
-                "target": dep["target"],
-                "kind": dep["kind"],
-                "registry": dep.get("registry"),
-                "explicit_name_in_toml": dep.get("package"),
-            }
-            for dep in deps
-        ],
-        "features": cargo_toml.get("features", {}),
-        "links": cargo_toml.get("package", {}).get("links"),
-        "rust_version": cargo_toml.get("package", {}).get("rust-version"),
-    }
 
 
 def test_cargo_publish_and_index_fidelity(
@@ -186,6 +127,34 @@ def test_cargo_publish_ignores_tampered_json_metadata(
     # The index entry should match crates.io (i.e. the Cargo.toml), not the tampered JSON
     pulp_entry = get_index_entry(base, "se/rd/serde", "1.0.210")
     assert_index_entry_matches_upstream(pulp_entry, upstream_index_entry)
+
+
+def test_cargo_publish_octet_stream_content_type(
+    delete_orphans_pre,
+    rust_repo_factory,
+    rust_distribution_factory,
+    cargo_registry_url,
+):
+    """Publish should accept Content-Type: application/octet-stream.
+
+    Current Cargo omits Content-Type entirely; a proposed upstream fix
+    will send application/octet-stream instead.  The server must accept both.
+    """
+    crate_name = "serde"
+    crate_version = "1.0.210"
+
+    crate_path, _ = download_crate_from_upstream(crate_name, crate_version)
+    with open(crate_path, "rb") as f:
+        crate_bytes = f.read()
+
+    metadata = build_publish_metadata(crate_path, crate_name, crate_version)
+
+    repository = rust_repo_factory()
+    distribution = rust_distribution_factory(repository=repository.pulp_href, allow_uploads=True)
+    base = cargo_registry_url(distribution.base_path)
+
+    response = cargo_publish(base, metadata, crate_bytes, content_type="application/octet-stream")
+    assert response.status_code == 200, response.text
 
 
 def test_cargo_publish_uploads_disabled(

--- a/pulp_rust/tests/functional/api/test_yank.py
+++ b/pulp_rust/tests/functional/api/test_yank.py
@@ -1,30 +1,26 @@
 """Functional tests for Cargo yank/unyank support."""
 
-import json
 import hashlib
+import json
 from urllib.parse import urljoin
 
-import aiohttp
-import asyncio
 import pytest
-from aiohttp.client_exceptions import ClientResponseError
+from requests.exceptions import HTTPError
 
 from pulp_rust.tests.functional.utils import (
+    CARGO_AUTH_HEADERS,
     CRATES_IO_URL,
+    cargo_api_request,
     download_file,
     get_index_entry,
 )
 
 
-def cargo_api_request(url, method="DELETE"):
-    """Make a DELETE or PUT request to the Cargo API."""
-
-    async def _request():
-        async with aiohttp.ClientSession(raise_for_status=True) as session:
-            async with session.request(method, url, verify_ssl=False) as response:
-                return json.loads(await response.read())
-
-    return asyncio.run(_request())
+def cargo_yank_request(url, method="DELETE"):
+    """Make an authenticated DELETE or PUT request to the Cargo yank/unyank API."""
+    response = cargo_api_request(method, url, headers=CARGO_AUTH_HEADERS)
+    response.raise_for_status()
+    return response.json()
 
 
 def get_all_index_entries(cargo_url, sparse_path):
@@ -84,7 +80,7 @@ def test_yank_happy_path(populated_repo):
 
     # Yank via Cargo API
     yank_url = urljoin(base_url, "api/v1/crates/itoa/1.0.0/yank")
-    result = cargo_api_request(yank_url, method="DELETE")
+    result = cargo_yank_request(yank_url, method="DELETE")
     assert result["ok"] is True
 
     # Verify now yanked
@@ -98,14 +94,14 @@ def test_unyank_happy_path(populated_repo):
 
     # Yank first
     yank_url = urljoin(base_url, "api/v1/crates/itoa/1.0.0/yank")
-    cargo_api_request(yank_url, method="DELETE")
+    cargo_yank_request(yank_url, method="DELETE")
 
     entry = get_index_entry(base_url, "it/oa/itoa", "1.0.0")
     assert entry["yanked"] is True
 
     # Unyank
     unyank_url = urljoin(base_url, "api/v1/crates/itoa/1.0.0/unyank")
-    result = cargo_api_request(unyank_url, method="PUT")
+    result = cargo_yank_request(unyank_url, method="PUT")
     assert result["ok"] is True
 
     # Verify no longer yanked
@@ -127,9 +123,9 @@ def test_yank_nonexistent_package(
     base_url = cargo_registry_url(distribution.base_path)
 
     yank_url = urljoin(base_url, "api/v1/crates/nonexistent/0.0.0/yank")
-    with pytest.raises(ClientResponseError) as exc:
-        cargo_api_request(yank_url, method="DELETE")
-    assert exc.value.status == 404
+    with pytest.raises(HTTPError) as exc:
+        cargo_yank_request(yank_url, method="DELETE")
+    assert exc.value.response.status_code == 404
 
 
 def test_yank_no_repository(
@@ -141,9 +137,9 @@ def test_yank_no_repository(
     base_url = cargo_registry_url(distribution.base_path)
 
     yank_url = urljoin(base_url, "api/v1/crates/itoa/1.0.0/yank")
-    with pytest.raises(ClientResponseError) as exc:
-        cargo_api_request(yank_url, method="DELETE")
-    assert exc.value.status == 404
+    with pytest.raises(HTTPError) as exc:
+        cargo_yank_request(yank_url, method="DELETE")
+    assert exc.value.response.status_code == 404
 
 
 # --- Idempotency ---
@@ -155,13 +151,13 @@ def test_yank_idempotent(populated_repo, rust_repo_api_client):
     repo_href = populated_repo["repository"].pulp_href
 
     yank_url = urljoin(base_url, "api/v1/crates/itoa/1.0.0/yank")
-    cargo_api_request(yank_url, method="DELETE")
+    cargo_yank_request(yank_url, method="DELETE")
 
     repo_after_first = rust_repo_api_client.read(repo_href)
     first_version = repo_after_first.latest_version_href
 
     # Yank again — should be no-op
-    result = cargo_api_request(yank_url, method="DELETE")
+    result = cargo_yank_request(yank_url, method="DELETE")
     assert result["ok"] is True
 
     repo_after_second = rust_repo_api_client.read(repo_href)
@@ -177,7 +173,7 @@ def test_unyank_idempotent(populated_repo, rust_repo_api_client):
     before_version = repo_before.latest_version_href
 
     unyank_url = urljoin(base_url, "api/v1/crates/itoa/1.0.0/unyank")
-    result = cargo_api_request(unyank_url, method="PUT")
+    result = cargo_yank_request(unyank_url, method="PUT")
     assert result["ok"] is True
 
     repo_after = rust_repo_api_client.read(repo_href)
@@ -219,7 +215,7 @@ def test_yank_isolation_across_repositories(
 
     # Yank in repo A only
     yank_url = urljoin(repos["a"]["base_url"], "api/v1/crates/itoa/1.0.0/yank")
-    cargo_api_request(yank_url, method="DELETE")
+    cargo_yank_request(yank_url, method="DELETE")
 
     # Repo A should show yanked, repo B should not
     entry_a = get_index_entry(repos["a"]["base_url"], "it/oa/itoa", "1.0.0")
@@ -229,10 +225,10 @@ def test_yank_isolation_across_repositories(
 
     # Yank in repo B too, then unyank only in A
     yank_url_b = urljoin(repos["b"]["base_url"], "api/v1/crates/itoa/1.0.0/yank")
-    cargo_api_request(yank_url_b, method="DELETE")
+    cargo_yank_request(yank_url_b, method="DELETE")
 
     unyank_url = urljoin(repos["a"]["base_url"], "api/v1/crates/itoa/1.0.0/unyank")
-    cargo_api_request(unyank_url, method="PUT")
+    cargo_yank_request(unyank_url, method="PUT")
 
     # A should be not-yanked, B should remain yanked
     entry_a = get_index_entry(repos["a"]["base_url"], "it/oa/itoa", "1.0.0")
@@ -253,7 +249,7 @@ def test_yank_creates_new_repo_version(populated_repo, rust_repo_api_client):
     version_before = repo_before.latest_version_href
 
     yank_url = urljoin(base_url, "api/v1/crates/itoa/1.0.0/yank")
-    cargo_api_request(yank_url, method="DELETE")
+    cargo_yank_request(yank_url, method="DELETE")
 
     repo_after = rust_repo_api_client.read(repo_href)
     assert repo_after.latest_version_href != version_before
@@ -268,7 +264,7 @@ def test_partial_yank(populated_repo):
 
     # Yank only 1.0.0
     yank_url = urljoin(base_url, "api/v1/crates/itoa/1.0.0/yank")
-    cargo_api_request(yank_url, method="DELETE")
+    cargo_yank_request(yank_url, method="DELETE")
 
     # 1.0.0 should be yanked
     entry_100 = get_index_entry(base_url, "it/oa/itoa", "1.0.0")
@@ -293,7 +289,7 @@ def test_download_still_works_after_yank(populated_repo):
 
     # Yank
     yank_url = urljoin(base_url, "api/v1/crates/itoa/1.0.0/yank")
-    cargo_api_request(yank_url, method="DELETE")
+    cargo_yank_request(yank_url, method="DELETE")
 
     # Download should still work
     after = download_file(download_url)

--- a/pulp_rust/tests/functional/utils.py
+++ b/pulp_rust/tests/functional/utils.py
@@ -1,16 +1,20 @@
 import hashlib
 import json
+import struct
 import tempfile
 
 import aiohttp
 import asyncio
+import requests
 from dataclasses import dataclass
+
+from pulp_rust.app.auth import STUB_TOKEN
+from pulp_rust.app.utils import extract_cargo_toml, extract_dependencies
 
 CRATES_IO_URL = "sparse+https://index.crates.io/"
 CRATES_IO_DOWNLOAD_URL = "https://static.crates.io/crates/"
+CARGO_AUTH_HEADERS = {"Authorization": STUB_TOKEN}
 
-# Fields from the sparse index that Pulp should faithfully reproduce.
-# "yanked" is excluded because it depends on per-repo yank state, not upstream.
 # Fields from the sparse index that Pulp should faithfully reproduce.
 # "yanked" is excluded because it depends on per-repo yank state, not upstream.
 # "v" is excluded because it's a schema version marker that older crates.io entries omit
@@ -30,6 +34,22 @@ class Download:
         self.response_obj = response_obj
 
 
+# --- Low-level HTTP helpers ---
+
+
+def cargo_api_request(method, url, **kwargs):
+    """Make an HTTP request to Cargo API endpoints, ignoring .netrc.
+
+    CI environments have a .netrc file that the ``requests`` library uses to
+    silently inject Basic auth headers, which interferes with tests that verify
+    unauthenticated or wrong-token requests are rejected.
+    """
+    kwargs.setdefault("verify", False)
+    with requests.Session() as s:
+        s.trust_env = False
+        return s.request(method, url, **kwargs)
+
+
 def download_file(url, auth=None, headers=None):
     """Download a file.
 
@@ -45,6 +65,97 @@ async def _download_file(url, auth=None, headers=None):
     async with aiohttp.ClientSession(auth=auth, raise_for_status=True) as session:
         async with session.get(url, verify_ssl=False, headers=headers) as response:
             return Download(body=await response.read(), response_obj=response)
+
+
+# --- Cargo publish helpers ---
+
+
+def _build_cargo_publish_body(metadata, crate_bytes):
+    """Build the binary request body that ``cargo publish`` sends.
+
+    Format (per Cargo registry web API spec):
+        4 bytes: JSON metadata length (little-endian u32)
+        N bytes: JSON metadata (UTF-8)
+        4 bytes: .crate file length (little-endian u32)
+        M bytes: .crate file (binary)
+    """
+    json_bytes = json.dumps(metadata).encode("utf-8")
+    return (
+        struct.pack("<I", len(json_bytes))
+        + json_bytes
+        + struct.pack("<I", len(crate_bytes))
+        + crate_bytes
+    )
+
+
+def cargo_publish(url, metadata, crate_bytes, content_type=None):
+    """Send a publish request mimicking ``cargo publish``.
+
+    The body is a custom binary format (length-prefixed JSON metadata +
+    .crate file), not valid JSON.  The *content_type* parameter controls the
+    Content-Type header: ``None`` omits it (current Cargo behaviour) and
+    ``"application/octet-stream"`` matches the fix proposed upstream.
+    """
+    body = _build_cargo_publish_body(metadata, crate_bytes)
+    headers = dict(CARGO_AUTH_HEADERS)
+    if content_type is not None:
+        headers["Content-Type"] = content_type
+    return cargo_api_request(
+        "PUT",
+        f"{url}api/v1/crates/new",
+        data=body,
+        headers=headers,
+    )
+
+
+def minimal_publish_request(url, headers=None):
+    """Send a minimal publish request to the Cargo publish endpoint.
+
+    Builds a tiny fake crate body — useful for testing auth and validation
+    without needing a real .crate file.
+    """
+    metadata = {"name": "fake", "vers": "0.0.1", "deps": [], "features": {}}
+    return cargo_api_request(
+        "PUT",
+        f"{url}api/v1/crates/new",
+        data=_build_cargo_publish_body(metadata, b"fake"),
+        headers=headers or {},
+    )
+
+
+def build_publish_metadata(crate_path, crate_name, crate_version):
+    """Extract metadata from a .crate file and format it for the publish API.
+
+    Cargo uses "version_req" (not "req") and "explicit_name_in_toml" (not "package")
+    per the Cargo registry web API spec.
+    """
+    cargo_toml = extract_cargo_toml(crate_path, crate_name, crate_version)
+    deps = extract_dependencies(cargo_toml)
+
+    return {
+        "name": crate_name,
+        "vers": crate_version,
+        "deps": [
+            {
+                "name": dep["name"],
+                "version_req": dep["req"],
+                "features": dep["features"],
+                "optional": dep["optional"],
+                "default_features": dep["default_features"],
+                "target": dep["target"],
+                "kind": dep["kind"],
+                "registry": dep.get("registry"),
+                "explicit_name_in_toml": dep.get("package"),
+            }
+            for dep in deps
+        ],
+        "features": cargo_toml.get("features", {}),
+        "links": cargo_toml.get("package", {}).get("links"),
+        "rust_version": cargo_toml.get("package", {}).get("rust-version"),
+    }
+
+
+# --- Index helpers ---
 
 
 def parse_index_entry(body, version):
@@ -73,6 +184,9 @@ def get_index_entry(url, sparse_path, version):
     return entry
 
 
+# --- Upstream helpers ---
+
+
 def download_crate_from_upstream(name, version):
     """Download a .crate file directly from crates.io and return (path, sha256)."""
     url = f"{CRATES_IO_DOWNLOAD_URL}{name}/{name}-{version}.crate"
@@ -85,6 +199,9 @@ def download_crate_from_upstream(name, version):
 
     cksum = hashlib.sha256(downloaded.body).hexdigest()
     return tmp.name, cksum
+
+
+# --- Assertion helpers ---
 
 
 def assert_index_entry_matches_upstream(pulp_entry, upstream_entry):


### PR DESCRIPTION
Users must set their token to
"i_understand_that_pulp_rust_does_not_support_proper_auth_yet" to perform a publish or yank operation. If the token isn't set with this value, auth will fail.

Assisted-By: claude-opus-4.6

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
