### PR TITLE
Use separate serializer for token create response

### DIFF
--- a/pulp_rust/app/serializers.py
+++ b/pulp_rust/app/serializers.py
@@ -277,19 +277,24 @@ class RustDistributionSerializer(core_serializers.DistributionSerializer):
 
 class CargoTokenSerializer(core_serializers.ModelSerializer):
     pulp_href = core_serializers.IdentityField(view_name="cargo/tokens-detail")
-    token = serializers.CharField(
-        read_only=True,
-        help_text=_("The token value. Shown once at creation, null otherwise."),
-    )
 
     class Meta:
         model = models.RustCargoToken
         fields = core_serializers.ModelSerializer.Meta.fields + (
             "name",
-            "token",
             "last_used",
         )
-        read_only_fields = ("token", "last_used")
+        read_only_fields = ("last_used",)
+
+
+class CargoTokenCreateResponseSerializer(CargoTokenSerializer):
+    token = serializers.CharField(
+        read_only=True,
+        help_text=_("The token value. Only shown once at creation time."),
+    )
+
+    class Meta(CargoTokenSerializer.Meta):
+        fields = CargoTokenSerializer.Meta.fields + ("token",)
 
 
 class YankSerializer(serializers.Serializer):

--- a/pulp_rust/app/viewsets.py
+++ b/pulp_rust/app/viewsets.py
@@ -107,13 +107,18 @@ class CargoTokenViewSet(NamedModelViewSet, CreateModelMixin, ListModelMixin, Des
     def get_queryset(self):
         return super().get_queryset().filter(user=self.request.user)
 
+    def get_serializer_class(self):
+        if self.action == "create":
+            return serializers.CargoTokenCreateResponseSerializer
+        return serializers.CargoTokenSerializer
+
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         raw_token = f"crg_{secrets.token_hex(20)}"
         token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
         serializer.save(user=request.user, token_hash=token_hash)
-        data = serializer.data
+        data = self.get_serializer(serializer.instance).data
         data["token"] = raw_token
         return Response(data, status=201)
 

--- a/pulp_rust/tests/functional/api/test_auth.py
+++ b/pulp_rust/tests/functional/api/test_auth.py
@@ -198,7 +198,7 @@ def test_token_not_returned_on_list(
     tokens = rust_token_api_client.list()
     assert tokens.count >= 1
     for t in tokens.results:
-        assert t.token is None
+        assert not hasattr(t, "token")
 
 
 # --- Distribution-scoped permissions ---


### PR DESCRIPTION
Split CargoTokenSerializer into a base serializer (without token field) for list/retrieve and a CargoTokenCreateResponseSerializer (with token) for create responses. This avoids exposing an always-null token field in the list schema and produces more accurate OpenAPI bindings.

Assisted-By: Claude Opus 4.6